### PR TITLE
bump sinatra version in gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
     rack (2.0.3)
     rack-protection (2.0.0)
       rack
-    sinatra (2.0.0)
+    sinatra (2.0.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
       rack-protection (= 2.0.0)


### PR DESCRIPTION
> The sinatra dependency defined in Gemfile.lock has a known moderate severity security vulnerability in version range = 2.0.0 and should be updated.